### PR TITLE
Use configuration provided credentials for AMQP.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## Version 0.5.4
+
+Correct support of usernames and passwords in AMQP connections.
+
 ## Version 0.5.3
 
 ### Client Side Certificate Support for HTTP

--- a/spec/event_source/protocols/amqp/bunny_connection_proxy_spec.rb
+++ b/spec/event_source/protocols/amqp/bunny_connection_proxy_spec.rb
@@ -180,3 +180,29 @@ RSpec.describe EventSource::Protocols::Amqp::BunnyConnectionProxy do
     end
   end
 end
+
+RSpec.describe EventSource::Protocols::Amqp::BunnyConnectionProxy, "given a url with non-default credentials" do
+  let(:username) { "A USERNAME" }
+  let(:password) { "A PASSWORD!" }
+
+  # rubocop:disable Lint/UriEscapeUnescape
+  let(:connection_url) do
+    "amqp://#{URI.escape(username)}:#{URI.escape(password)}@localhost:5672"
+  end
+  # rubocop:enable Lint/UriEscapeUnescape
+
+  let(:server) do
+    {
+      url: connection_url
+    }
+  end
+
+  let(:connection_params) do
+    EventSource::Protocols::Amqp::BunnyConnectionProxy.connection_params_for(server)
+  end
+
+  it "correctly sets the username and password" do
+    expect(connection_params[:username]).to eq username
+    expect(connection_params[:password]).to eq password
+  end
+end


### PR DESCRIPTION
Respect configuration provided usernames and passwords for AMQP.