### PR TITLE
Improve puma performance.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -35,4 +35,4 @@ jobs:
 #          bundle exec rubocop
       - name: Run rspec
         run: |
-          bundle exec rspec
+          ES_HOSTING_MODE=listener bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_source (0.5.7)
+    event_source (0.6.0)
       addressable (>= 2.8.0)
       bunny (>= 2.14)
       deep_merge (~> 1.2.0)
@@ -323,7 +323,7 @@ GEM
     ruby2_keywords (0.0.4)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    set (1.0.2)
+    set (1.0.3)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)

--- a/lib/event_source/configure.rb
+++ b/lib/event_source/configure.rb
@@ -4,6 +4,7 @@ require_relative "configure/types"
 require_relative "configure/servers"
 require_relative "configure/contracts"
 require_relative "configure/operations"
+require_relative "configure/mode"
 require_relative "configure/config"
 
 module EventSource

--- a/lib/event_source/configure/config.rb
+++ b/lib/event_source/configure/config.rb
@@ -26,6 +26,10 @@ module EventSource
         @server_key = value&.to_sym
       end
 
+      def mode
+        @mode ||= ::EventSource::Configure::Mode.parse(ENV['ES_HOSTING_MODE'])
+      end
+
       attr_writer :async_api_schemas
 
       def servers

--- a/lib/event_source/configure/mode.rb
+++ b/lib/event_source/configure/mode.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module EventSource
+  module Configure
+    # Server boot mode.  Used for performance and configuration settings.
+    class Mode
+
+      attr_reader :value
+
+      def initialize(val)
+        @value = val
+      end
+
+      def listener?
+        @value == :listener
+      end
+
+      def publisher?
+        @value == :publisher
+      end
+
+      def self.publisher
+        self.new(:publisher)
+      end
+
+      def self.parse(mode_string)
+        return publisher if mode_string.blank?
+        mode_sym = mode_string.to_sym
+        raise ::EventSource::Error::InvalidModeError, "\"#{mode_string}\" is an invalid mode. Must be empty, null, \"publisher\", or \"listener\"." if ![:publisher, :listener].include?(mode_sym)
+        self.new(mode_string.to_sym)
+      end
+    end
+  end
+end

--- a/lib/event_source/error.rb
+++ b/lib/event_source/error.rb
@@ -21,6 +21,7 @@ module EventSource
     ConstantNotDefined = Class.new(Error)
     ContractNotFound = Class.new(Error)
     EventNameUndefined = Class.new(Error)
+    InvalidModeError = Class.new(Error)
     FileAccessError = Class.new(Error)
     InvalidChannelsResourceError = Class.new(Error)
     PublisherAlreadyRegisteredError = Class.new(Error)

--- a/lib/event_source/protocols/amqp/bunny_queue_proxy.rb
+++ b/lib/event_source/protocols/amqp/bunny_queue_proxy.rb
@@ -73,6 +73,12 @@ module EventSource
 
           @channel_proxy.subject.prefetch(prefetch)
 
+          # Do not spawn consumers in the 'publisher' mode
+          unless ::EventSource.config.mode.listener?
+            logger.debug "In publisher mode, not booting subscription"
+            return
+          end
+
           if options[:block]
             spawn_thread(options) { add_consumer(subscriber_klass, options) }
           else

--- a/lib/event_source/version.rb
+++ b/lib/event_source/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EventSource
-  VERSION = "0.5.7"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
After examination, we've discovered that Puma instance (i.e. user-facing web-UI) responsiveness suffers significantly when the system is under heavy asynchronous load (such as during redeterminations).

The reason behind this is that the event source AMQP subscribers are also started on the Puma webserver instances, instead of only on listener instances.  This results in AMQP subscribers consuming messages, doing work, and 'stealing' resources from the Puma webserver threads on the same instance.

This update enables a DevOps engineer to opt-in to the creation of asynchronous AMQP subscribers by setting an environment variable `ES_HOSTING_MODE` to a value of `listener`.  Only when this environment variable is explicitly set, and only when it is explicitly set to the value of `listener`, will AMQP subscribers be created.

Important to note is:
1. The default for running AMQP subscribers is now **opt-in** - tests and local docker environments will need to be updated to reflect this.
2. All applications which use event source now have access to this functionality, without further developer effort.