### PR TITLE
update log level to warn for default and make logging level configurable

### DIFF
--- a/lib/event_source/configure/config.rb
+++ b/lib/event_source/configure/config.rb
@@ -8,6 +8,10 @@ module EventSource
     class Config
       include EventSource::Logging
 
+      def initialize
+        @log_level = :warn
+      end
+
       # TODO: add default for pub_sub_root
       attr_writer :pub_sub_root, :protocols, :server_configurations
       attr_accessor :app_name, :log_level

--- a/lib/event_source/configure/config.rb
+++ b/lib/event_source/configure/config.rb
@@ -10,6 +10,7 @@ module EventSource
 
       # TODO: add default for pub_sub_root
       attr_writer :pub_sub_root, :protocols, :server_configurations
+      attr_accessor :app_name, :log_level
 
       def load_protocols
         @protocols.each do |protocol|
@@ -164,8 +165,6 @@ module EventSource
           '.'
         end
       end
-
-      attr_accessor :app_name
     end
   end
 end

--- a/lib/event_source/logging.rb
+++ b/lib/event_source/logging.rb
@@ -24,7 +24,7 @@ module EventSource
         ::Logging.appenders.rolling_file(
           'log/event_source.log',
           age: 'daily',
-          level: :debug,
+          level: EventSource.config.log_level,
           keep: 7,
           layout: ::Logging.layouts.json
         )

--- a/spec/config_helper.rb
+++ b/spec/config_helper.rb
@@ -2,6 +2,7 @@
 
 EventSource.configure do |config|
   config.protocols = %w[amqp http]
+  config.log_level = :warn
 end
 
 EventSource.initialize!

--- a/spec/event_source/logging_spec.rb
+++ b/spec/event_source/logging_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'config_helper'
 require 'event_source/logging'
 
 class LogService

--- a/spec/rails_app/config/initializers/event_source.rb
+++ b/spec/rails_app/config/initializers/event_source.rb
@@ -5,6 +5,7 @@ EventSource.configure do |config|
   config.pub_sub_root = Pathname.pwd.join('spec', 'rails_app', 'app', 'event_source')
   config.server_key = Rails.env.to_sym
   config.app_name = :enroll
+  config.log_level = :warn
 
   config.servers do |server|
     # mitc


### PR DESCRIPTION
This is related to this ticket: [Store and transmit cryptographically protected passwords](https://www.pivotaltracker.com/story/show/185608993)

Failed the IRS audit for the FTI app; looks to be caused by the connection params for RabbitMQ being output to the log file. Issue appears to be in [this file](https://github.com/ideacrew/event_source/blob/trunk/lib/event_source/protocols/amqp/bunny_connection_proxy.rb#L66-L67) where we log the connection details to the `:debug` logger. 

Change default log level to `:warn` instead of `:debug`, but allow log level to be overridden. 

This change is a dependency of [this PR](https://github.com/ideacrew/fti/pull/68) to FTI app; where we explicitly set the log level to `:warn` or  `:debug` (based on the environment)