### PR TITLE
fixes for system account

### DIFF
--- a/lib/event_source/operations/build_message_options.rb
+++ b/lib/event_source/operations/build_message_options.rb
@@ -38,17 +38,17 @@ module EventSource
 
       def append_account_details(headers)
         output = FetchSession.new.call
+        return output unless output.success?
+
+        session, current_user, system_account = output.value!
         account = {}
 
-        if output.success?
-          session, current_user = output.value!
+        if session.present? && current_user.present?
           account[:session] = session&.symbolize_keys
+          account[:id] = current_user&.id&.to_s
         else
-          # Create system account user <admin@dc.gov> when session is not available
-          current_user = system_account if defined?(system_account)
+          account[:id] = system_account&.id&.to_s
         end
-
-        account[:id] = current_user&.id&.to_s
         headers[:account] = account
 
         Success(headers)

--- a/lib/event_source/operations/fetch_session.rb
+++ b/lib/event_source/operations/fetch_session.rb
@@ -13,8 +13,9 @@ module EventSource
         helper = yield include_session_helper
         session = yield fetch_session
         current_user = yield fetch_current_user
+        system_account = yield fetch_system_account
 
-        Success([session, current_user])
+        Success([session, current_user, system_account])
       end
 
       private
@@ -40,6 +41,14 @@ module EventSource
           Success(current_user)
         else
           Failure("current_user is not defined")
+        end
+      end
+
+      def fetch_system_account
+        if respond_to?(:system_account)
+          Success(system_account)
+        else
+          Failure("system_account is not defined")
         end
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186780742

Modify the fetch_session service to include rendering of the system_account, allowing it to be utilized for events in situations where a live session might not be present.